### PR TITLE
Bug fixes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 base = "/ttp-fs
-publish = "/build"
+publish = "/ttp-fs/build"
 command = "yarn build"
 
 [[redirects]]

--- a/ttp-fs/src/App.js
+++ b/ttp-fs/src/App.js
@@ -6,7 +6,7 @@ import Portfolio from "./components/Portfolio";
 import Transactions from "./components/Transactions";
 import PurchaseStock from "./components/PurchaseStock";
 import Navigation from "./components/Navigation";
-import { withRouter } from "react-router-dom";
+import { withRouter, Redirect, Switch } from "react-router-dom";
 import PrivateRoute from "./components/PrivateRoute";
 
 function App(props) {
@@ -16,11 +16,14 @@ function App(props) {
       props.location.pathname === "/signup" ? null : (
         <Navigation history={props.history} />
       )}
-      <Route path="/login" component={Login} />
-      <Route path="/signup" component={Signup} />
-      <PrivateRoute exact path="/" component={Portfolio} />
-      <PrivateRoute path="/transactions" component={Transactions} />
-      <PrivateRoute path="/purchase" component={PurchaseStock} />
+      <Switch>
+        <Route path="/login" component={Login} />
+        <Route path="/signup" component={Signup} />
+        <PrivateRoute exact path="/" component={Portfolio} />
+        <PrivateRoute path="/transactions" component={Transactions} />
+        <PrivateRoute path="/purchase" component={PurchaseStock} />
+        <Redirect from="*" to="/" />
+      </Switch>
     </div>
   );
 }

--- a/ttp-fs/src/App.js
+++ b/ttp-fs/src/App.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Route } from "react-router-dom";
 import Login from "./components/Login";
 import Signup from "./components/Signup";
 import Portfolio from "./components/Portfolio";
@@ -17,11 +16,19 @@ function App(props) {
         <Navigation history={props.history} />
       )}
       <Switch>
-        <Route path="/login" component={Login} />
-        <Route path="/signup" component={Signup} />
-        <PrivateRoute exact path="/" component={Portfolio} />
-        <PrivateRoute path="/transactions" component={Transactions} />
-        <PrivateRoute path="/purchase" component={PurchaseStock} />
+        <PrivateRoute path="/login" component={Login} testPrivate={false} />
+        <PrivateRoute path="/signup" component={Signup} testPrivate={false} />
+        <PrivateRoute exact path="/" component={Portfolio} testPrivate={true} />
+        <PrivateRoute
+          path="/transactions"
+          component={Transactions}
+          testPrivate={true}
+        />
+        <PrivateRoute
+          path="/purchase"
+          component={PurchaseStock}
+          testPrivate={true}
+        />
         <Redirect from="*" to="/" />
       </Switch>
     </div>

--- a/ttp-fs/src/actions/index.js
+++ b/ttp-fs/src/actions/index.js
@@ -12,12 +12,12 @@ export const signUp = userInfo => dispatch => {
   return axios
     .post(`${endpoint}/api/auth/register/`, userInfo)
     .then(res => {
-      dispatch({ type: SIGN_UP_SUCCESS, payload: res.data.token });
       localStorage.setItem("token", res.data.token);
       localStorage.setItem("userID", res.data.userID);
+      return dispatch({ type: SIGN_UP_SUCCESS, payload: res.data.token });
     })
     .catch(err => {
-      dispatch({
+      return dispatch({
         type: SIGN_UP_FAILURE,
         payload: `${err.message}. ${err.response.data.message}`
       });
@@ -33,12 +33,12 @@ export const signIn = userInfo => dispatch => {
   return axios
     .post(`${endpoint}/api/auth/login/`, userInfo)
     .then(res => {
-      dispatch({ type: SIGN_IN_SUCCESS, payload: res.data.token });
       localStorage.setItem("token", res.data.token);
       localStorage.setItem("userID", res.data.userID);
+      return dispatch({ type: SIGN_IN_SUCCESS, payload: res.data.token });
     })
     .catch(err => {
-      dispatch({
+      return dispatch({
         type: SIGN_IN_FAILURE,
         payload: `${err.message}. ${err.response.data.message}`
       });
@@ -66,10 +66,10 @@ export const getTransactions = user_id => dispatch => {
         }
       }
       const portfolio = Object.values(table);
-      dispatch({ type: GET_TRANSACTIONS_SUCCESS, payload, portfolio });
+      return dispatch({ type: GET_TRANSACTIONS_SUCCESS, payload, portfolio });
     })
     .catch(err => {
-      dispatch({
+      return dispatch({
         type: GET_TRANSACTIONS_FAILURE,
         payload: `${err.message}. ${err.response.data.message}`
       });
@@ -104,14 +104,14 @@ export const makeTransaction = transactionInfo => dispatch => {
   return axiosAuth()
     .post(`${endpoint}/api/transactions`, transactionInfo)
     .then(res => {
-      dispatch({
+      return dispatch({
         type: MAKE_TRANSACTION_SUCCESS,
         payload: res.data,
         balance: transactionInfo.quantity * transactionInfo.price
       });
     })
     .catch(err => {
-      dispatch({
+      return dispatch({
         type: MAKE_TRANSACTION_FAILURE,
         payload: `${err.message}. ${err.response.data.message}`
       });

--- a/ttp-fs/src/actions/index.js
+++ b/ttp-fs/src/actions/index.js
@@ -178,3 +178,12 @@ export const fetchMovement = symbols => dispatch => {
       dispatch({ type: FETCH_MOVEMENT_FAILURE, payload: err.message });
     });
 };
+
+export const LOG_OUT = "LOG_OUT";
+
+export const logOut = () => {
+  localStorage.clear();
+  return {
+    type: LOG_OUT
+  };
+};

--- a/ttp-fs/src/components/Login.js
+++ b/ttp-fs/src/components/Login.js
@@ -26,7 +26,6 @@ class Login extends Component {
 
   signIn = (e, userInfo) => {
     e.preventDefault();
-    console.log(userInfo);
     this.props
       .signIn(userInfo)
       .then(res => {

--- a/ttp-fs/src/components/Navigation.js
+++ b/ttp-fs/src/components/Navigation.js
@@ -1,9 +1,11 @@
 import React, { memo } from "react";
+import { connect } from "react-redux";
 import { NavLink } from "react-router-dom";
+import { logOut } from "../actions";
 
 const Navigation = props => {
   const logOut = () => {
-    localStorage.clear();
+    props.logOut();
     props.history.push("/login");
   };
   return (
@@ -23,4 +25,9 @@ const Navigation = props => {
   );
 };
 
-export default memo(Navigation);
+const MemNav = memo(Navigation);
+
+export default connect(
+  null,
+  { logOut }
+)(MemNav);

--- a/ttp-fs/src/components/Portfolio.js
+++ b/ttp-fs/src/components/Portfolio.js
@@ -19,7 +19,7 @@ class Portfolio extends Component {
           console.error(err);
         });
     } else if (this.props.stockList.length > 0) {
-      if (Object.keys(this.props.prices) === 0) {
+      if (Object.keys(this.props.prices).length === 0) {
         this.fetchPrices();
       }
     }

--- a/ttp-fs/src/components/PrivateRoute.js
+++ b/ttp-fs/src/components/PrivateRoute.js
@@ -2,15 +2,26 @@ import React from "react";
 import { Route, Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 
-const PrivateRoute = ({ component: Component, ...rest }) => {
-  return (
-    <Route
-      {...rest}
-      render={props =>
-        rest.signedIn ? <Component {...props} /> : <Redirect to="/login" />
-      }
-    />
-  );
+const PrivateRoute = ({ component: Component, testPrivate, ...rest }) => {
+  if (testPrivate) {
+    return (
+      <Route
+        {...rest}
+        render={props =>
+          rest.signedIn ? <Component {...props} /> : <Redirect to="/login" />
+        }
+      />
+    );
+  } else {
+    return (
+      <Route
+        {...rest}
+        render={props =>
+          !rest.signedIn ? <Component {...props} /> : <Redirect to="/" />
+        }
+      />
+    );
+  }
 };
 
 const mapStateToProps = state => ({

--- a/ttp-fs/src/components/PurchaseStock.js
+++ b/ttp-fs/src/components/PurchaseStock.js
@@ -36,7 +36,7 @@ class PurchaseStock extends Component {
     });
   };
 
-  makeTransaction = (e, transacInfo) => {
+  makeTransaction = e => {
     e.preventDefault();
     // Make request to IEX API and check price. If quantity * price < user balance, then make the transaction.
     const { balance, id } = this.props.user; // User funds
@@ -94,10 +94,7 @@ class PurchaseStock extends Component {
       return (
         <div className="purchase">
           <h1>Balance - ${balance.toFixed(2)}</h1>
-          <form
-            className="purchase-form"
-            onSubmit={e => this.makeTransaction(e, this.state.transaction)}
-          >
+          <form className="purchase-form" onSubmit={this.makeTransaction}>
             <FormControl>
               <InputLabel className="label">Symbol</InputLabel>
               <Input

--- a/ttp-fs/src/components/PurchaseStock.js
+++ b/ttp-fs/src/components/PurchaseStock.js
@@ -6,6 +6,7 @@ import Button from "@material-ui/core/Button";
 import FormControl from "@material-ui/core/FormControl";
 import Input from "@material-ui/core/Input";
 import InputLabel from "@material-ui/core/InputLabel";
+import Spinner from "./Spinner";
 
 class PurchaseStock extends Component {
   state = {
@@ -89,7 +90,7 @@ class PurchaseStock extends Component {
     const { user, fetchingUser } = this.props;
     const { balance, id } = user;
     if (fetchingUser || !id) {
-      return <h1>Loading...</h1>;
+      return <Spinner />;
     } else {
       return (
         <div className="purchase">

--- a/ttp-fs/src/components/PurchaseStock.js
+++ b/ttp-fs/src/components/PurchaseStock.js
@@ -69,9 +69,11 @@ class PurchaseStock extends Component {
                 alert(`Transaction failed ${err}.`);
               });
           } else {
+            // If the IEX API returns a valid result, but the price of the stock * quantity of stock is greater than the user balance, then the user does not have enough funds.
             alert("You do not have enough funds.");
           }
         } else {
+          // If the IEX API does not return a result, then the provided symbol was invalid.
           alert("Please enter a valid symbol.");
         }
       })

--- a/ttp-fs/src/components/PurchaseStock.js
+++ b/ttp-fs/src/components/PurchaseStock.js
@@ -39,7 +39,7 @@ class PurchaseStock extends Component {
   makeTransaction = (e, transacInfo) => {
     e.preventDefault();
     // Make request to IEX API and check price. If quantity * price < user balance, then make the transaction.
-    const { balance } = this.props.user; // User funds
+    const { balance, id } = this.props.user; // User funds
     const { quantity, symbol } = this.state.transaction;
     axios
       .get(`https://api.iextrading.com/1.0/tops?symbols=${symbol}`)
@@ -47,11 +47,14 @@ class PurchaseStock extends Component {
         const response = res.data[0];
         if (response) {
           if (balance >= quantity * response.lastSalePrice) {
-            const finalTransaction = { ...transacInfo };
-            finalTransaction.quantity = Number(quantity);
-            finalTransaction.price = response.lastSalePrice;
-            finalTransaction.sector = response.sector;
-            finalTransaction.security_type = response.securityType;
+            const finalTransaction = {
+              user_id: id,
+              quantity: Number(quantity),
+              symbol: response.symbol,
+              price: response.lastSalePrice,
+              sector: response.sector,
+              security_type: response.securityType
+            };
             this.props
               .makeTransaction(finalTransaction)
               .then(res => {

--- a/ttp-fs/src/components/Transaction.js
+++ b/ttp-fs/src/components/Transaction.js
@@ -6,7 +6,7 @@ const Transaction = props => {
     <div className="transaction">
       <h3>BUY ({symbol})</h3>
       <h3>
-        {quantity} shares @ {price}
+        {quantity} shares @ {price.toFixed(2)}
       </h3>
     </div>
   );

--- a/ttp-fs/src/reducers/index.js
+++ b/ttp-fs/src/reducers/index.js
@@ -172,7 +172,9 @@ const reducer = (state = initialState, action) => {
         error: action.payload
       };
     case LOG_OUT:
-      return initialState;
+      return {
+        ...initialState
+      };
 
     default:
       return state;

--- a/ttp-fs/src/reducers/index.js
+++ b/ttp-fs/src/reducers/index.js
@@ -16,7 +16,8 @@ import {
   MAKE_TRANSACTION_FAILURE,
   FETCH_PRICES,
   FETCH_PRICES_SUCCESS,
-  FETCH_PRICES_FAILURE
+  FETCH_PRICES_FAILURE,
+  LOG_OUT
 } from "../actions";
 
 const initialState = {
@@ -170,6 +171,8 @@ const reducer = (state = initialState, action) => {
         fetchingPrices: false,
         error: action.payload
       };
+    case LOG_OUT:
+      return initialState;
 
     default:
       return state;

--- a/ttp-fs/src/reducers/index.js
+++ b/ttp-fs/src/reducers/index.js
@@ -173,7 +173,8 @@ const reducer = (state = initialState, action) => {
       };
     case LOG_OUT:
       return {
-        ...initialState
+        ...initialState,
+        signedIn: false
       };
 
     default:


### PR DESCRIPTION
- `netlify.toml` file was missing a ".
- Previously, logging out as one user and then logging in as another would render state data from the previous user if the app was not refreshed. Logging out will now return the store to its initial state.
- Used `<Switch />` react-router-dom component to redirect users to home route if they try entering an invalid URL. This can later be changed to redirect to a custom error page.
- Typo in `componentDidMount()` of `<Portfolio />` was causing prices to initialize as NaN in some cases. Fixed.
- Trying to access the login or signup components while logged in will redirect to the home route.
- Functions that were chaining off of thunks were not working correctly due to missing `return` statements in the `.then()` and `.catch()` of these thunks. Now fixed.
- To avoid `stockList` recognizing the same stock differently due to casing, making a transaction will always use the symbol that comes back from the IEX API, rather than the user-entered symbol.
- Used `<Spinner />` in `<PurchaseStock />` while loading in user info.